### PR TITLE
Issue#207 app#get hash

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python3
 import uuid
+<<<<<<< HEAD
 import logging
+=======
+import binascii
+>>>>>>> Using hexdigest instead of digest
 
 from flask import Flask, send_from_directory, jsonify, request, session
 from logging import Formatter
@@ -52,6 +56,18 @@ def validate_signup_body(req):
     return True
 
 
+<<<<<<< HEAD
+=======
+def get_hash(password, salt):
+    m = hashlib.sha512()
+    m.update(salt.encode('utf8'))
+    m.update(password.encode('utf8'))
+    hex = m.hexdigest()
+    binary_hex_digest = binascii.unhexlify(hex)
+    return binary_hex_digest
+
+
+>>>>>>> Using hexdigest instead of digest
 def email_exists(email):
     return User.query.filter(User.email == email).count() > 0
 

--- a/app.py
+++ b/app.py
@@ -1,10 +1,6 @@
 #!/usr/bin/env python3
 import uuid
-<<<<<<< HEAD
 import logging
-=======
-import binascii
->>>>>>> Using hexdigest instead of digest
 
 from flask import Flask, send_from_directory, jsonify, request, session
 from logging import Formatter
@@ -56,8 +52,6 @@ def validate_signup_body(req):
     return True
 
 
-<<<<<<< HEAD
-=======
 def get_hash(password, salt):
     m = hashlib.sha512()
     m.update(salt.encode('utf8'))
@@ -65,7 +59,6 @@ def get_hash(password, salt):
     return m.digest()
 
 
->>>>>>> Using hexdigest instead of digest
 def email_exists(email):
     return User.query.filter(User.email == email).count() > 0
 

--- a/app.py
+++ b/app.py
@@ -62,9 +62,7 @@ def get_hash(password, salt):
     m = hashlib.sha512()
     m.update(salt.encode('utf8'))
     m.update(password.encode('utf8'))
-    hex = m.hexdigest()
-    binary_hex_digest = binascii.unhexlify(hex)
-    return binary_hex_digest
+    return m.digest()
 
 
 >>>>>>> Using hexdigest instead of digest

--- a/test.py
+++ b/test.py
@@ -57,6 +57,14 @@ class GetHashTestCase(BaseTestCase):
 
         self.assertEqual(expected_hash, actual_hash)
 
+    def test_get_hash_empty_password(self):
+        password = ''
+        salt = 'salt'
+        expected_hash = self.get_hash(password, salt)
+        actual_hash = app.get_hash(password, salt)
+
+        self.assertEqual(expected_hash, actual_hash)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test.py
+++ b/test.py
@@ -3,6 +3,7 @@ import unittest
 from models import User
 from database import db_session, clear_db
 import hashlib
+import binascii
 
 
 class BaseTestCase(unittest.TestCase):
@@ -43,21 +44,21 @@ class EmailExistsTestCase(BaseTestCase):
 
 class GetHashTestCase(BaseTestCase):
 
-    def get_hash(self, password, salt):
-        m = hashlib.sha512()
-        m.update(salt.encode('utf8'))
-        m.update(password.encode('utf8'))
-        return m.digest()
-
     def test_get_hash(self):
         password = 'pass'
         salt = 'salt'
-        expected_hash = self.get_hash(password, salt)
+        expected_hash = ("4ab3490b9dd9fbcd6eb9ec6e"
+                         "2078a99c8de5d4d0ae1371fa"
+                         "ad97fdc83774dbeeec52c971"
+                         "c41971f71b131587c1becb17"
+                         "07435b24771d392631298647ba04e37d")
+        binary_exp_hash = binascii.unhexlify(expected_hash)
         actual_hash = app.get_hash(password, salt)
+        print(binascii.hexlify(actual_hash))
 
-        self.assertEqual(expected_hash, actual_hash)
+        self.assertEqual(binary_exp_hash, actual_hash)
 
-    def test_get_hash_empty_password(self):
+    def get_hash_empty_password(self):
         password = ''
         salt = 'salt'
         expected_hash = self.get_hash(password, salt)
@@ -65,7 +66,7 @@ class GetHashTestCase(BaseTestCase):
 
         self.assertEqual(expected_hash, actual_hash)
 
-    def test_get_hash_empty_salt(self):
+    def get_hash_empty_salt(self):
         password = 'pass'
         salt = ''
         expected_hash = self.get_hash(password, salt)

--- a/test.py
+++ b/test.py
@@ -2,6 +2,7 @@ import app
 import unittest
 from models import User
 from database import db_session, clear_db
+import hashlib
 
 
 class BaseTestCase(unittest.TestCase):
@@ -38,6 +39,23 @@ class EmailExistsTestCase(BaseTestCase):
         self.insert_email_fixture()
         actual = app.email_exists("test@test.com")
         self.assertTrue(actual)
+
+
+class GetHashTestCase(BaseTestCase):
+
+    def get_hash(self, password, salt):
+        m = hashlib.sha512()
+        m.update(salt.encode('utf8'))
+        m.update(password.encode('utf8'))
+        return m.digest()
+
+    def test_get_hash(self):
+        password = 'pass'
+        salt = 'salt'
+        expected_hash = self.get_hash(password, salt)
+        actual_hash = app.get_hash(password, salt)
+
+        self.assertEqual(expected_hash, actual_hash)
 
 
 if __name__ == '__main__':

--- a/test.py
+++ b/test.py
@@ -65,6 +65,14 @@ class GetHashTestCase(BaseTestCase):
 
         self.assertEqual(expected_hash, actual_hash)
 
+    def test_get_hash_empty_salt(self):
+        password = 'pass'
+        salt = ''
+        expected_hash = self.get_hash(password, salt)
+        actual_hash = app.get_hash(password, salt)
+
+        self.assertEqual(expected_hash, actual_hash)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test.py
+++ b/test.py
@@ -54,25 +54,34 @@ class GetHashTestCase(BaseTestCase):
                          "07435b24771d392631298647ba04e37d")
         binary_exp_hash = binascii.unhexlify(expected_hash)
         actual_hash = app.get_hash(password, salt)
-        print(binascii.hexlify(actual_hash))
 
         self.assertEqual(binary_exp_hash, actual_hash)
 
-    def get_hash_empty_password(self):
+    def test_get_hash_empty_password(self):
         password = ''
         salt = 'salt'
-        expected_hash = self.get_hash(password, salt)
+        expected_hash = ("2e3fce77cf8c4c7478a96d20"
+                         "7c1c39715892cac84a18cbec"
+                         "9b634f4bc22b390b48cd30a4"
+                         "df2e7ebbaee65c346a662c5be"
+                         "2d12441322f7a4bac821a382c4af091")
+        binary_exp_hash = binascii.unhexlify(expected_hash)
         actual_hash = app.get_hash(password, salt)
 
-        self.assertEqual(expected_hash, actual_hash)
+        self.assertEqual(binary_exp_hash, actual_hash)
 
-    def get_hash_empty_salt(self):
+    def test_get_hash_empty_salt(self):
         password = 'pass'
         salt = ''
-        expected_hash = self.get_hash(password, salt)
+        expected_hash = ("5b722b307fce6c944905d132"
+                         "691d5e4a2214b7fe92b73892"
+                         "0eb3fce3a90420a19511c301"
+                         "0a0e7712b054daef5b57bad5"
+                         "9ecbd93b3280f210578f547f4aed4d25")
+        binary_exp_hash = binascii.unhexlify(expected_hash)
         actual_hash = app.get_hash(password, salt)
 
-        self.assertEqual(expected_hash, actual_hash)
+        self.assertEqual(binary_exp_hash, actual_hash)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
fix #207 
## Changements

Il est préférable d'utiliser la méthode hexdigest au lieu de digest.
https://stackoverflow.com/questions/2436621/python-decoding-issue-with-hashlib-digest-method
https://stackoverflow.com/questions/18174332/output-of-hashlib-sha512-digest-has-odd-characters
